### PR TITLE
Fix/user sign in access

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
 
       post 'auth/sign_in', to: 'authentication#sign_in'
       get 'auth/verify', to: 'authentication#verify_token'
-      post 'auth/request', to: 'authentication#request_token'
+      get 'auth/request', to: 'authentication#request_token'
     end
   end
 


### PR DESCRIPTION
### Changelogs

- Provide `access-token` upon successful sign in even if `email_verified == false`
- Change `/auth/request` route from `POST` to `GET` request